### PR TITLE
[fix] eslint rule 충돌 해결 방향

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
     '@typescript-eslint/no-redeclare': 'error',
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
     'no-console': ['warn', { allow: ['warn', 'error', 'table'] }],
+    '@typescript-eslint/no-explicit-any': 'off',
     'no-undef': 'off',
     'no-redeclare': 'off',
     'no-unused-vars': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
-    'no-duplicate-imports': 'error',
+    // 'no-duplicate-imports': 'error',
     'import/no-cycle': [
       'error',
       {
@@ -43,12 +43,9 @@ module.exports = {
         ignoreExternal: true,
       },
     ],
-    '@typescript-eslint/no-unused-vars': [
-      'error',
-      { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
-    ],
+    '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-redeclare': 'error',
-    '@typescript-eslint/consistent-type-imports': 'error',
+    // '@typescript-eslint/consistent-type-imports': 'error',
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
     'no-console': ['warn', { allow: ['warn', 'error', 'table'] }],
     'no-undef': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
-    // 'no-duplicate-imports': 'error',
+    'no-duplicate-imports': 'error',
     'import/no-cycle': [
       'error',
       {
@@ -45,7 +45,6 @@ module.exports = {
     ],
     '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-redeclare': 'error',
-    // '@typescript-eslint/consistent-type-imports': 'error',
     'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
     'no-console': ['warn', { allow: ['warn', 'error', 'table'] }],
     'no-undef': 'off',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,13 +56,7 @@ export default function Home() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
+          <Image aria-hidden src="https://nextjs.org/icons/file.svg" alt="File icon" width={16} height={16} />
           Learn
         </a>
         <a
@@ -71,13 +65,7 @@ export default function Home() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
+          <Image aria-hidden src="https://nextjs.org/icons/window.svg" alt="Window icon" width={16} height={16} />
           Examples
         </a>
         <a
@@ -86,13 +74,7 @@ export default function Home() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
+          <Image aria-hidden src="https://nextjs.org/icons/globe.svg" alt="Globe icon" width={16} height={16} />
           Go to nextjs.org →
         </a>
       </footer>


### PR DESCRIPTION
## 📌 개요

* 린트 Rule 충돌 발생
  * import 시 type 은 `type` 키워드를 붙여서 import 하는 것이 type이 아닌 일반 함수, 컴포넌트 import 시 중복 import 되는 상황

## 📋 변경사항

- [ ] 1️⃣ [duplicate import rule을 off 할 것인지](https://github.com/depromeet/16th-team2-FE/pull/5#discussion_r1938406573) (같은 파일의 type과 컴포넌트, 함수가 두 줄에 걸쳐서 import 되나 type 구분은 유지)
- [ ] 2️⃣ [type import rule 을 off 할 것인지](https://github.com/depromeet/16th-team2-FE/pull/5#discussion_r1938406580) (같은 파일의 type과 컴포넌트, 함수가 한 줄에 import 되나 type 구분이 없어짐)

### 기능

### 화면

| 기능 | 스크린샷 |
| ---- | -------- |
| 린트 충돌 상황 | <img width="910" alt="image" src="https://github.com/user-attachments/assets/75e4aa29-ae05-4c98-9fa6-8d4771e1fd47" /> |

### 함수

## ✅ 체크사항

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 스타일 및 규칙 준수 확인
- [ ] UI가 변경된 경우 스크린샷 첨부 여부 확인
